### PR TITLE
gp: avoid failure if /dev/shm not present

### DIFF
--- a/src/gp.ml
+++ b/src/gp.ml
@@ -1,7 +1,11 @@
 open Printf
 open Owl
 
-let default_tmp_root = if Sys.is_directory "/dev/shm" then "/dev/shm" else "/tmp"
+let default_tmp_root =
+  match Unix.stat "/dev/shm" with
+  | {st_kind = S_DIR; _} -> "/dev/shm"
+  | _ -> "/tmp"
+  | exception Unix.Unix_error (Unix.ENOENT, _, _) -> "/tmp"
 
 type prms =
   { tmp_root : string


### PR DESCRIPTION
The `Sys.is_directory fpath` call fails with
```
Fatal error: exception Sys_error("fpath: No such file or directory")
```
when the file is not present. The suggested solution
prevents this issue.

A better solution would also check if the folders are writable,
and if not create a different local temp dir on the fly, but
I think it is overkill in this case.

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>